### PR TITLE
Add Install instructions, with a requirements.txt

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,20 @@
+# Semantic-DB Installation instructions
+
+Currently, these instructions have only been tested on ubuntu bionic.
+
+The Semantic DB requires tkinter, an external dependency. To install tkinter
+on ubuntu bionic, do:
+
+'''bash
+sudo apt install python3-tk
+'''
+
+The Semanic DB needs to be cloned from github to be used as of now:
+
+'''bash
+git clone https://github.com/GarryMorrison/Semantic-DB.git
+cd Semantic-DB
+pip3 install -r requirements.txt
+'''
+
+The sdb-console should now be usable

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+parsley
+numpy
+matplotlib


### PR DESCRIPTION
Merge this if you don't want me to write a setup.py file and turn this into a package.
I have another branch set up with a setup.py file, which allows installation using pip3. but currently,
the way this project is set up, the sdb-console and parsley grammars aren't included in the package.

If we were to make the package more like [this](https://github.com/BillMills/python-package-example) example package,
we could make this installable with pip. Then we could run the sdb-console using something like:
`python3 -m Semantic-DB`
and be dropped into a console from anywhere.

Tl;dr If you're fine with this, merge it, if you want to package the Semantic-DB, don't, and I'll move things around into a package.