### PR TITLE
remove numpy dependence

### DIFF
--- a/semantic_db/code.py
+++ b/semantic_db/code.py
@@ -4,7 +4,7 @@
 # Author: Garry Morrison
 # email: garry -at- semantic-db.org
 # Date: 2018
-# Update: 31/7/2018
+# Update: 27/8/2018
 # Copyright: GPLv3
 #
 # Usage: 
@@ -1249,15 +1249,15 @@ class sequence(object):
             seq.add(sp)
         return seq
 
-    def noise(self, t):  # do we use this anywhere?
-        seq = sequence(self.name, [])
-        for x in self.data:
-            try:
-                value = x + np.random.normal(0, t)  # enable adding noise to superpositions??
-            except:
-                value = x
-            seq.add(value)
-        return seq
+    # def noise(self, t):  # do we use this anywhere?
+    #     seq = sequence(self.name, [])
+    #     for x in self.data:
+    #         try:
+    #             value = x + np.random.normal(0, t)  # enable adding noise to superpositions??
+    #         except:
+    #             value = x
+    #         seq.add(value)
+    #     return seq
 
     def smooth(self, k):  # hrmm... maybe if type superposition, apply coeff_sort()?
         try:

--- a/semantic_db/functions.py
+++ b/semantic_db/functions.py
@@ -6,7 +6,7 @@
 # Author: Garry Morrison
 # email: garry -at- semantic-db.org
 # Date: 2014
-# Update: 31/7/2018
+# Update: 27/8/2018
 # Copyright: GPLv3
 #
 # A collection of functions that apply to kets, superpositions and sequences.
@@ -24,7 +24,7 @@ from semantic_db.sigmoids import *
 import math
 from math import factorial
 from pprint import pprint
-import numpy as np
+# import numpy as np
 from matplotlib import pyplot as plt
 import datetime
 from time import gmtime, strftime, ctime, sleep
@@ -909,9 +909,13 @@ def plot(one):
 
     fig = plt.figure()
     width = 0.1
-    ind = np.arange(len(values))
+    # ind = np.arange(len(values))
+    ind = list(range(len(values)))
+    xticks_ind = [x + width / 2 for x in ind]
+    # print('ind: %s' % ind)
     plt.bar(ind, values, width=width)
-    plt.xticks(ind + width / 2, labels)
+    # plt.xticks(ind + width / 2, labels)
+    plt.xticks(xticks_ind, labels)
     fig.autofmt_xdate()
     plt.show()
     return ket('plot')

--- a/semantic_db/functions.py
+++ b/semantic_db/functions.py
@@ -908,13 +908,10 @@ def plot(one):
         values.append(value)
 
     fig = plt.figure()
-    width = 0.1
-    # ind = np.arange(len(values))
+    width = 0.2
     ind = list(range(len(values)))
-    xticks_ind = [x + width / 2 for x in ind]
-    # print('ind: %s' % ind)
+    xticks_ind = [x + width /10 for x in ind]
     plt.bar(ind, values, width=width)
-    # plt.xticks(ind + width / 2, labels)
     plt.xticks(xticks_ind, labels)
     fig.autofmt_xdate()
     plt.show()


### PR DESCRIPTION
from code.py we remove the sequence.noise() function. Doesn't seem to be
used, and if it is I'm sure we can implement it without numpy
from functions.py we remove np.arange() dependence in plot().
Now we should be numpy free!